### PR TITLE
Fix issue #78 - TimeOffset being applied twice to lastBought datetime

### DIFF
--- a/CryptoGramBot/EventBus/Handlers/TradeNotificationHandler.cs
+++ b/CryptoGramBot/EventBus/Handlers/TradeNotificationHandler.cs
@@ -44,7 +44,7 @@ namespace CryptoGramBot.EventBus.Handlers
                 profitPercentage = tradesProfitResponse.ProfitPercentage;
                 btcProfit = tradesProfitResponse.BtcProfit;
                 dollarProfit = tradesProfitResponse.DollarProfit;
-                lastBought = tradesProfitResponse.LastBoughtTime + TimeSpan.FromHours(_config.TimeOffset);
+                lastBought = tradesProfitResponse.LastBoughtTime;
             }
 
             var sb = new StringBuffer();


### PR DESCRIPTION
Just removed the first apply of the TimeOffset to the lastBought value since the message formatting lines below it already apply the TimeOffset.